### PR TITLE
Excluded indexes

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,4 @@
 const nconf = require('nconf');
-const path = require('path');
 
 nconf
     .argv()

--- a/database/google-data-storage.js
+++ b/database/google-data-storage.js
@@ -1,5 +1,5 @@
 // Imports the Google Cloud client library
-const Datastore = require('@google-cloud/datastore');
+const Datastore = require('@google-cloud/datastore')
 const props = require('../config');
 
 // Instantiate the datatstore
@@ -8,27 +8,30 @@ const datastore = Datastore({
   projectId: projectId,
 });
 
-
-// tick = {
-//  bid :  
-//  bidSize : 
-//  ask :
-//  askSize :
-//  dailyChange :
-//  dailyChangePerc :
-//  lastPrice :
-//  volume :
-//  high :
-//  low : 
-//  symbol :
-//  timestamp :
-// };
-
+/**
+ * Save an entity to the google data storage using the specified entity key.
+ * see https://googlecloudplatform.github.io/google-cloud-node/#/docs/datastore/1.1.0/datastore?method=save for documentation
+ * @param {*} entityKey - entity key
+ * @param {*} entityData - entity data
+ */
 function saveData(entityKey, entityData) {
     const taskKey = datastore.key(entityKey);
     const entity = {
         key: taskKey,
-        data: entityData
+        // Included: Symbol, Timestamp
+        excludeFromIndexes: [
+            'ask',
+            'askSize',
+            'bid',
+            'bidSize',
+            'dailyChange',
+            'dailyChangePerc',
+            'high',
+            'lastPrice',
+            'low',
+            'volume',
+        ],
+        data: entityData,
     };
 
     datastore.save(entity)

--- a/database/google-data-storage.js
+++ b/database/google-data-storage.js
@@ -1,5 +1,5 @@
 // Imports the Google Cloud client library
-const Datastore = require('@google-cloud/datastore')
+const Datastore = require('@google-cloud/datastore');
 const props = require('../config');
 
 // Instantiate the datatstore

--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ ws.on('open', () => ws.subscribeTicker('BTCUSD'));
 ws.on('ticker', (pair, ticker) => {
     ticker.symbol = 'BTCUSD';
     ticker.timestamp = new Date();
-    databaseSave("Ticker" ,ticker);
+    databaseSave('Ticker', ticker);
 });


### PR DESCRIPTION
Exclude certain properties from the Datastore indexes. Sadly this does not update the current indexes, but there is no way around this. (See https://cloud.google.com/datastore/docs/concepts/indexes#datastore-properties-nodejs, the section on excluded properties)